### PR TITLE
since slack and  webhook configs are the same also mentioned in slack section

### DIFF
--- a/configuration/outputs.md
+++ b/configuration/outputs.md
@@ -360,8 +360,9 @@ If enabled, the SignalFx integration will stream analytics and insights to an Si
 
 ## Trigger Destinations
 
-### **Slack**
+### **Slack/Webhook**
 
+Slack and webhook configuration are the same so you can follow slack to add a webhook trigger.<br>
 If enabled, the Slack integration will stream notifications and alerts to the specified Slack channel
 
 | Key | Description | Required |


### PR DESCRIPTION
- section header changed as slack/webhook and a description added

![Screenshot 2021-06-08 at 14 41 44](https://user-images.githubusercontent.com/2900456/121195724-c196bc00-c867-11eb-8daf-89557d287f41.png)
