### PR TITLE
Used cross-platform uninstaller for Mac

### DIFF
--- a/installation/macos.md
+++ b/installation/macos.md
@@ -66,7 +66,6 @@ cat /opt/edgedelta/agent/config.yml
 Make sure to run uninstallation process as root.
 
 ```text
-launchctl remove edgedelta
-rm -rfd /opt/edgedelta
+sudo bash -c "$(curl -L https://release.edgedelta.com/uninstall.sh)"
 ```
 


### PR DESCRIPTION
Below one-liner works just fine for Mac updating mac page accordingly. 
`sudo bash -c "$(curl -L https://release.edgedelta.com/uninstall.sh)"`

# Testing

```
$ sudo ED_API_KEY=********  bash -c "$(curl -L https://release.edgedelta.com/v0.1.8/install.sh)"
  ....
Uncompressing EdgeDelta Agent  100%
-n
EdgeDelta Agent extracted itself
EdgeDelta Agent installated into path: /opt/edgedelta/agent/
2021-06-08T17:50:57.513+0300	INFO	program/service_handler.go:45	Running agent in service control command mode
2021-06-08T17:50:57.552+0300	INFO	program/service_handler.go:45	Running agent in service control command mode
EdgeDelta Agent installed and started
Removed temporary folder:/Users/ozgur/src/doc/edgedelta
+ exit
$ sudo ps aux  | grep edgedelta
ozgur            34400   0.6  0.0  4268340    744 s003  S+    5:51PM   0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn edgedelta
root             33242   0.0  0.3  5239816  50856   ??  Ss    5:50PM   0:02.79 /opt/edgedelta/agent/edgedelta

$ sudo tail -n 2 /opt/edgedelta/agent/edgedelta.log
2021-06-08T17:51:07.557+0300	DEBUG	health/health.go:180	component ozgur-local-devel|stat|Ozgurs-MacBook-Pro.local|Docker|wurstmeister/kafka-e778892a3db2|tailer has successfully registered to health.
2021-06-08T17:51:07.557+0300	DEBUG	pipeline/pipeline_manager.go:104	New tailer is started for source: ozgur-local-devel|stat|Ozgurs-MacBook-Pro.local|Docker|wurstmeister/kafka-e778892a3db2

$ sudo bash -c "$(curl -L https://release.edgedelta.com/uninstall.sh)"

 % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   314  100   314    0     0    342      0 --:--:-- --:--:-- --:--:--   341
++ getconf LONG_BIT
+ BITS=64
+ '[' 64 == 32 ']'
+ echo 'Removing agent service'
Removing agent service
+ sudo /opt/edgedelta/agent/edgedelta -s uninstall
2021-06-08T17:52:09.078+0300	INFO	program/service_handler.go:45	Running agent in service control command mode
+ echo 'Removing agent folder'
Removing agent folder
+ sudo rm -rf /opt/edgedelta/agent/
+ echo Done
Done


(base) ➜  doc git:(ozgur/update_macosx_uninstall) ✗ sudo ps aux  | grep edgedelta
ozgur            34449   0.0  0.0  4268340    744 s003  S+    5:52PM   0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn edgedelta
(base) ➜  doc git:(ozgur/update_macosx_uninstall) ✗ sudo ls /opt/edgedelta/agent
ls: /opt/edgedelta/agent: No such file or directory
```